### PR TITLE
ord wallet inscriptions Can't get the inscription link correctly

### DIFF
--- a/src/subcommand/wallet/inscriptions.rs
+++ b/src/subcommand/wallet/inscriptions.rs
@@ -15,10 +15,10 @@ pub(crate) fn run(options: Options) -> Result {
   let unspent_outputs = index.get_unspent_outputs(Wallet::load(&options)?)?;
 
   let explorer = match options.chain() {
-    Chain::Mainnet => "https://ordinals.com/inscription/",
+    Chain::Mainnet => "https://ordinalslite.com/inscription/",
     Chain::Regtest => "http://localhost/inscription/",
-    Chain::Signet => "https://signet.ordinals.com/inscription/",
-    Chain::Testnet => "https://testnet.ordinals.com/inscription/",
+    Chain::Signet => "https://signet.ordinalslite.com/inscription/",
+    Chain::Testnet => "https://testnet.ordinalslite.com/inscription/",
   };
 
   let mut output = Vec::new();


### PR DESCRIPTION
The link in the code is still ordinals.com in btc, it should be changed to ordinalslite.com