### PR TITLE
fix: handle Litecoin MWEB transaction payloads

### DIFF
--- a/crates/mockcore/src/lib.rs
+++ b/crates/mockcore/src/lib.rs
@@ -213,7 +213,7 @@ impl Handle {
     .unwrap()
   }
 
-  pub fn state(&self) -> MutexGuard<State> {
+  pub fn state(&self) -> MutexGuard<'_, State> {
     self.state.lock().unwrap()
   }
 

--- a/crates/mockcore/src/server.rs
+++ b/crates/mockcore/src/server.rs
@@ -16,7 +16,7 @@ impl Server {
     Self { network, state }
   }
 
-  fn state(&self) -> MutexGuard<State> {
+  fn state(&self) -> MutexGuard<'_, State> {
     self.state.lock().unwrap()
   }
 

--- a/crates/mockcore/src/state.rs
+++ b/crates/mockcore/src/state.rs
@@ -232,8 +232,8 @@ impl State {
             .get(i)
             .cloned()
             .unwrap_or(value_per_output),
-          script_pubkey: if template.receiver.is_some() {
-            template.receiver.as_ref().unwrap().script_pubkey()
+          script_pubkey: if let Some(receiver) = &template.receiver {
+            receiver.script_pubkey()
           } else if template.p2tr {
             let secp = Secp256k1::new();
             let keypair = KeyPair::new(&secp, &mut rand::thread_rng());

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -296,17 +296,17 @@
 
                     <nav class="nav-wrapper" aria-label="Page navigation">
                         <!-- Mobile navigation buttons -->
-                        {{#previous}}
-                            <a rel="prev" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                        {{#if previous}}
+                            <a rel="prev" href="{{ path_to_root }}{{ previous.link }}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
                                 <i class="fa fa-angle-left"></i>
                             </a>
-                        {{/previous}}
+                        {{/if}}
 
-                        {{#next}}
-                            <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                        {{#if next}}
+                            <a rel="next prefetch" href="{{ path_to_root }}{{ next.link }}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
                                 <i class="fa fa-angle-right"></i>
                             </a>
-                        {{/next}}
+                        {{/if}}
 
                         <div style="clear: both"></div>
                     </nav>
@@ -314,17 +314,17 @@
             </div>
 
             <nav class="nav-wide-wrapper" aria-label="Page navigation">
-                {{#previous}}
-                    <a rel="prev" href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                {{#if previous}}
+                    <a rel="prev" href="{{ path_to_root }}{{ previous.link }}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
                         <i class="fa fa-angle-left"></i>
                     </a>
-                {{/previous}}
+                {{/if}}
 
-                {{#next}}
-                    <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                {{#if next}}
+                    <a rel="next prefetch" href="{{ path_to_root }}{{ next.link }}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
                         <i class="fa fa-angle-right"></i>
                     </a>
-                {{/next}}
+                {{/if}}
             </nav>
 
         </div>

--- a/src/index/fetcher.rs
+++ b/src/index/fetcher.rs
@@ -87,36 +87,169 @@ impl Fetcher {
       break;
     }
 
-    // Return early on any error, because we need all results to proceed
-    if let Some(err) = results.iter().find_map(|res| res.error.as_ref()) {
+    if results.len() != txids.len() {
       return Err(anyhow!(
-        "failed to fetch raw transaction: code {} message {}",
+        "batched JSON-RPC returned {} results for {} txids",
+        results.len(),
+        txids.len()
+      ));
+    }
+
+    results.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut txs = Vec::with_capacity(txids.len());
+
+    for (expected_id, (txid, res)) in txids.iter().zip(results.into_iter()).enumerate() {
+      if res.id != expected_id {
+        return Err(anyhow!(
+          "batched JSON-RPC response id mismatch for {txid}: expected {expected_id}, got {}",
+          res.id
+        ));
+      }
+
+      match self.parse_batched_response(txid, res) {
+        Ok(tx) => txs.push(tx),
+        Err(error) => {
+          log::warn!(
+            "batched getrawtransaction decode failed for {txid}: {error}; retrying individually"
+          );
+
+          let tx = self
+            .get_transaction(*txid)
+            .await
+            .map_err(|single_error| {
+              anyhow!(
+                "failed to fetch transaction {txid} individually after batch failure: {single_error}"
+              )
+            })?;
+
+          txs.push(tx);
+        }
+      }
+    }
+
+    Ok(txs)
+  }
+
+  fn parse_batched_response(&self, txid: &Txid, res: JsonResponse<String>) -> Result<Transaction> {
+    if let Some(err) = res.error {
+      return Err(anyhow!(
+        "batched JSON-RPC error for {txid}: code {} message {}",
         err.code,
         err.message
       ));
     }
 
-    // Results from batched JSON-RPC requests can come back in any order, so we must sort them by id
-    results.sort_by(|a, b| a.id.cmp(&b.id));
+    let raw = res
+      .result
+      .ok_or_else(|| anyhow!("missing result for batched JSON-RPC response for {txid}"))?;
 
-    let txs = results
-      .into_iter()
-      .map(|res| {
-        res
-          .result
-          .ok_or_else(|| anyhow!("Missing result for batched JSON-RPC response"))
-          .and_then(|str| {
-            hex::decode(str)
-              .map_err(|e| anyhow!("Result for batched JSON-RPC response not valid hex: {e}"))
-          })
-          .and_then(|hex| {
-            consensus::deserialize(&hex).map_err(|e| {
-              anyhow!("Result for batched JSON-RPC response not valid bitcoin tx: {e}")
-            })
-          })
-      })
-      .collect::<Result<Vec<Transaction>>>()?;
-    Ok(txs)
+    self.deserialize_transaction(txid, &raw, "batched JSON-RPC response")
+  }
+
+  async fn get_transaction(&self, txid: Txid) -> Result<Transaction> {
+    let body = Value::Array(vec![json!({
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "getrawtransaction",
+      "params": [ txid ],
+    })])
+    .to_string();
+
+    let mut results = self.try_get_transactions(body).await?;
+
+    if results.len() != 1 {
+      return Err(anyhow!(
+        "single JSON-RPC response for {txid} returned {} results",
+        results.len()
+      ));
+    }
+
+    let res = results.pop().unwrap();
+
+    if let Some(err) = res.error {
+      return Err(anyhow!(
+        "single JSON-RPC error for {txid}: code {} message {}",
+        err.code,
+        err.message
+      ));
+    }
+
+    let raw = res
+      .result
+      .ok_or_else(|| anyhow!("missing result for single JSON-RPC response for {txid}"))?;
+
+    self.deserialize_transaction(&txid, &raw, "single JSON-RPC response")
+  }
+
+  fn deserialize_transaction(
+    &self,
+    txid: &Txid,
+    raw: &str,
+    source: &str,
+  ) -> Result<Transaction> {
+    let hex =
+      hex::decode(raw).map_err(|e| anyhow!("{source} for {txid} not valid hex: {e}"))?;
+
+    match consensus::deserialize(&hex) {
+      Ok(tx) => Ok(tx),
+      Err(error) => {
+        if let Some(tx) = self.try_deserialize_litecoin_mweb(txid, &hex)? {
+          log::warn!("{source} for {txid} required Litecoin MWEB fallback deserialization");
+          return Ok(tx);
+        }
+
+        Err(anyhow!("{source} for {txid} not valid bitcoin tx: {error}"))
+      }
+    }
+  }
+
+  fn try_deserialize_litecoin_mweb(
+    &self,
+    txid: &Txid,
+    raw: &[u8],
+  ) -> Result<Option<Transaction>> {
+    if raw.len() < 10 || raw[4] != 0 {
+      return Ok(None);
+    }
+
+    let flags = raw[5];
+    if flags & 8 == 0 {
+      return Ok(None);
+    }
+
+    let (_, consumed) = match consensus::encode::deserialize_partial::<Transaction>(raw) {
+      Ok(result) => result,
+      Err(_) => return Ok(None),
+    };
+
+    if consumed < 10 || consumed > raw.len() || raw.len() < 4 {
+      return Ok(None);
+    }
+
+    let body_end = consumed
+      .checked_sub(4)
+      .ok_or_else(|| anyhow!("partial deserialize for {txid} consumed too few bytes"))?;
+
+    if body_end < 6 {
+      return Ok(None);
+    }
+
+    let mut canonical = Vec::with_capacity(raw.len());
+    canonical.extend_from_slice(&raw[..4]);
+
+    if flags & 1 != 0 {
+      canonical.push(0);
+      canonical.push(1);
+    }
+
+    canonical.extend_from_slice(&raw[6..body_end]);
+    canonical.extend_from_slice(&raw[raw.len() - 4..]);
+
+    let tx = consensus::deserialize(&canonical)
+      .map_err(|error| anyhow!("Litecoin MWEB fallback deserialize failed for {txid}: {error}"))?;
+
+    Ok(Some(tx))
   }
 
   async fn try_get_transactions(&self, body: String) -> Result<Vec<JsonResponse<String>>> {

--- a/src/index/utxo_entry.rs
+++ b/src/index/utxo_entry.rs
@@ -41,7 +41,7 @@ pub struct UtxoEntry {
 }
 
 impl UtxoEntry {
-  pub fn parse(&self, index: &Index) -> ParsedUtxoEntry {
+  pub fn parse(&self, index: &Index) -> ParsedUtxoEntry<'_> {
     let sats;
     let mut script_pubkey = None;
     let mut inscriptions = None;

--- a/src/wallet/batch/plan.rs
+++ b/src/wallet/batch/plan.rs
@@ -461,13 +461,13 @@ impl Plan {
               Ok(ordinals::Terms {
                 cap: (terms.cap > 0).then_some(terms.cap),
                 height: (
-                  terms.height.and_then(|range| (range.start)),
-                  terms.height.and_then(|range| (range.end)),
+                  terms.height.and_then(|range| range.start),
+                  terms.height.and_then(|range| range.end),
                 ),
                 amount: Some(terms.amount.to_integer(etching.divisibility)?),
                 offset: (
-                  terms.offset.and_then(|range| (range.start)),
-                  terms.offset.and_then(|range| (range.end)),
+                  terms.offset.and_then(|range| range.start),
+                  terms.offset.and_then(|range| range.end),
                 ),
               })
             })


### PR DESCRIPTION
## Summary
- retry batched `getrawtransaction` decode failures individually so the real failing txid is visible
- fall back to canonical transaction deserialization when Litecoin includes MWEB extension payload bytes
- keep HogEx / MWEB bridge transactions from aborting indexing while preserving the transaction data ord uses

## Test plan
- [x] reproduce the failure against Litecoin mainnet block `2424429` with tx `c0406d4b5e6117fe0a703cbeb045ae81a616d74d93f238bbcbd085e3424aa682`
- [x] confirm Litecoin Core `getrawtransaction` and `decoderawtransaction` succeed for the same tx
- [x] run `cargo check --bin ord` in a Rust 1.76 container against this patch
- [x] rebuild the patched binary in Docker and verify indexing continues past the old failure range

## Notes
This fixes a Litecoin-specific serialization edge case rather than ordinals logic itself. The failing transactions are HogEx / MWEB bridge transactions whose serialized form includes optional MWEB payload bytes after the canonical transaction body.

Made with [Cursor](https://cursor.com)